### PR TITLE
Make less racy

### DIFF
--- a/syncgroup.go
+++ b/syncgroup.go
@@ -1,39 +1,47 @@
 package syncgroup
 
-import "sync"
+import (
+	"sync"
+	"sync/atomic"
+)
 
-// SyncGroup is a sync.WaitGroup that also allows tracked goroutines to "sync" their execution.
+// SyncGroup acts as a sync.WaitGroup which allows goroutes to Sync on one another.
 // The use case it was designed for batching, where you wish to accumulate something until it
 // reaches a certain size or time (tracked via the batcher), or if work is blocked on the batching.
 type SyncGroup struct {
-	running  sync.WaitGroup
-	syncing  sync.WaitGroup
-	finished sync.RWMutex
+	queued  int32
+	stopped int32
+	paused  int32
 
-	lock  sync.Mutex
-	count int
+	finished *sync.Cond
+	once     sync.Once
+}
+
+// Add sets how many jobs are being queued up
+func (sg *SyncGroup) Add(j int) {
+	sg.once.Do(func() {
+		sg.finished = sync.NewCond(&sync.Mutex{})
+	})
+
+	sg.finished.L.Lock()
+	atomic.AddInt32(&sg.queued, int32(j))
+	sg.finished.L.Unlock()
 }
 
 // Go runs a function in a goroutine, tracking it's execution state in the SyncGroup
 // The supplied function can call (*SyncGroup).Sync() to pause execution until all
 // tracked goroutines are also in a call to Sync()
 func (sg *SyncGroup) Go(fn func()) {
-	sg.lock.Lock()
-	defer sg.lock.Unlock()
-
-	sg.running.Add(1) // Must be called before sg.watch or it will immediately terminate
-	if sg.count == 0 {
-		sg.finished.Lock()
-		go sg.watch()
+	if sg.finished.L == nil {
+		panic("Cannot call SyncGroup.Go before SyncGroup.Add")
 	}
-	sg.count++
 
 	go func() {
 		defer func() {
-			sg.lock.Lock()
-			defer sg.lock.Unlock()
-			sg.count-- // Must be called before calling sg.running.Done() or sg.watch() will break
-			sg.running.Done()
+			sg.finished.L.Lock()
+			atomic.AddInt32(&sg.stopped, 1)
+			sg.finished.L.Unlock()
+			sg.finished.Broadcast()
 		}()
 
 		fn()
@@ -42,35 +50,39 @@ func (sg *SyncGroup) Go(fn func()) {
 
 // Wait will block until all tracked goroutines finish executing
 func (sg *SyncGroup) Wait() {
-	sg.finished.RLock()
-	sg.finished.RUnlock()
-}
-
-// Sync will block execution until all other tracked goroutines call Sync() or terminate
-func (sg *SyncGroup) Sync() {
-	sg.syncing.Add(1)
-	sg.running.Done()
-	sg.syncing.Wait()
-}
-
-// Watch maintains the (*SyncGroup).finished lock (used in Wait) and
-// calls Done on the syncing WaitGroup when deadlock is reached
-func (sg *SyncGroup) watch() {
-	defer sg.finished.Unlock()
-
 	for {
-		sg.running.Wait() // Wait for all goroutines to Sync() or terminate
-		// Theoretically there's a race condition here where you could call Go() between Wait() and Lock() running...
-		// But I don't know how to get around that
-		// If it _does_ happen, the calls to Add() below will have the wrong count and will likely panic
-		sg.lock.Lock()
-		if sg.count == 0 { // All done!
-			sg.lock.Unlock()
+		sg.finished.L.Lock()
+		if atomic.LoadInt32(&sg.queued) == atomic.LoadInt32(&sg.stopped) {
+			sg.finished.L.Unlock()
 			return
 		}
-
-		sg.running.Add(sg.count)
-		sg.syncing.Add(-1 * sg.count)
-		sg.lock.Unlock()
+		sg.finished.Wait()
+		sg.finished.L.Unlock()
 	}
+}
+
+// Sync will block until all goroutines are either finished or waiting on Sync
+func (sg *SyncGroup) Sync() {
+	sg.finished.L.Lock()
+	atomic.AddInt32(&sg.paused, 1)
+	sg.finished.L.Unlock()
+	sg.finished.Broadcast()
+
+	for {
+		sg.finished.L.Lock()
+		if sg.done() {
+			atomic.AddInt32(&sg.paused, -1)
+			sg.finished.L.Unlock()
+			return
+		}
+		sg.finished.Wait()
+		sg.finished.L.Unlock()
+	}
+}
+
+func (sg *SyncGroup) done() bool {
+	if atomic.LoadInt32(&sg.queued) == (atomic.LoadInt32(&sg.stopped) + atomic.LoadInt32(&sg.paused)) {
+		return true
+	}
+	return false
 }

--- a/syncgroup_examples_test.go
+++ b/syncgroup_examples_test.go
@@ -9,7 +9,7 @@ func ExampleSyncGroup() {
 	// It is expected that SyncGroup is used in libraries
 	// We represent that here with the randomFetcher struct
 	f := &randomFetcher{}
-
+	f.Add(10)
 	for i := 0; i < 10; i++ {
 		// The library author may require end-users to manually use SyncGroup.Go
 		// or may offer a utility method to abstract this away.

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -1,0 +1,129 @@
+package syncgroup_test
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/ossareh/syncgroup"
+)
+
+func TestSyncGroup_Wait(t *testing.T) {
+	// In the most basic case SyncGroup should behave like a (*sync.WaitGroup)
+	iters := 2000000
+	decrements := int32(iters)
+
+	sg := &syncgroup.SyncGroup{}
+	sg.Add(iters)
+
+	for i := 0; i < iters; i++ {
+		sg.Go(func() {
+			atomic.AddInt32(&decrements, -1)
+		})
+	}
+	sg.Wait()
+
+	if atomic.LoadInt32(&decrements) != 0 {
+		t.Errorf("TestSyncGroup_Wait expected=0 got=%d", decrements)
+	}
+}
+
+func TestSyncGroup_Sync(t *testing.T) {
+	// The real purpose of SyncGroup is to allow functions to Sync() on eachother
+	iters := 200000
+	decrements := int32(iters)
+	increments := int32(0)
+
+	sg := &syncgroup.SyncGroup{}
+	sg.Add(iters)
+
+	for i := 0; i < iters; i++ {
+		sg.Go(func() {
+			atomic.AddInt32(&decrements, -1)
+			sg.Sync()
+
+			if atomic.LoadInt32(&decrements) != 0 {
+				t.Errorf("TestSyncGroup_Sync goroutine expected=0 got=%d", decrements)
+			}
+			atomic.AddInt32(&increments, 2)
+		})
+	}
+	sg.Wait()
+
+	if atomic.LoadInt32(&increments) != int32(iters*2) {
+		t.Errorf("TestSyncGroup_Sync expected=%d got=%d", iters*2, increments)
+	}
+}
+
+func TestSyncGroup_Mixed(t *testing.T) {
+	// Covers the case of mixed function types, some that sync and some that don't
+	iters := 2000000
+	decrements := int32(iters)
+	increments := int32(0)
+
+	sg := &syncgroup.SyncGroup{}
+	sg.Add(iters)
+
+	for i := 0; i < iters; i++ {
+		if i%10 == 0 {
+			sg.Go(func() {
+				atomic.AddInt32(&decrements, -1)
+				sg.Sync()
+
+				if atomic.LoadInt32(&decrements) != 0 {
+					t.Errorf("TestSyncGroup_Mixed goroutine expected=0 got=%d", decrements)
+				}
+				atomic.AddInt32(&increments, 2)
+			})
+		} else {
+			sg.Go(func() {
+				atomic.AddInt32(&decrements, -1)
+			})
+		}
+	}
+
+	sg.Wait()
+
+	expected := int(iters/10) * 2
+	if atomic.LoadInt32(&increments) != int32(expected) {
+		t.Errorf("TestSyncGroup_Sync expected=%d got=%d", expected, increments)
+	}
+}
+
+func TestSyncGroup_MultiAdd(t *testing.T) {
+	// Add many batches
+	iters := 1000000
+	batches := 100
+	decrements := int32(iters)
+	increments := int32(0)
+
+	sg := &syncgroup.SyncGroup{}
+
+	for j := 0; j < batches; j++ {
+		sg.Add(iters / batches)
+
+		for i := 0; i < iters/batches; i++ {
+			if i%10 == 0 {
+				sg.Go(func() {
+					atomic.AddInt32(&decrements, -1)
+					sg.Sync()
+
+					if atomic.LoadInt32(&decrements) != 0 {
+						t.Errorf("TestSyncGroup_MultiAdd goroutine expected=0 got=%d", decrements)
+					}
+					atomic.AddInt32(&increments, 2)
+				})
+			} else {
+				sg.Go(func() {
+					atomic.AddInt32(&decrements, -1)
+				})
+			}
+		}
+	}
+
+	sg.Wait()
+
+	expected := int(iters/10) * 2
+	if atomic.LoadInt32(&increments) != int32(expected) {
+		t.Errorf("TestSyncGroup_Sync expected=%d got=%d", expected, increments)
+	}
+}

--- a/syncgroup_test.go
+++ b/syncgroup_test.go
@@ -1,15 +1,24 @@
 package syncgroup_test
 
 import (
+	"os"
 	"sync/atomic"
 	"testing"
 
 	"github.com/ossareh/syncgroup"
 )
 
+func iterCount(v int) int {
+	if e := os.Getenv("RACE_TEST"); e != "" {
+		return 30
+	}
+
+	return v
+}
+
 func TestSyncGroup_Wait(t *testing.T) {
 	// In the most basic case SyncGroup should behave like a (*sync.WaitGroup)
-	iters := 2000000
+	iters := iterCount(2000000)
 	decrements := int32(iters)
 
 	sg := &syncgroup.SyncGroup{}
@@ -29,7 +38,7 @@ func TestSyncGroup_Wait(t *testing.T) {
 
 func TestSyncGroup_Sync(t *testing.T) {
 	// The real purpose of SyncGroup is to allow functions to Sync() on eachother
-	iters := 200000
+	iters := iterCount(200000)
 	decrements := int32(iters)
 	increments := int32(0)
 
@@ -56,7 +65,7 @@ func TestSyncGroup_Sync(t *testing.T) {
 
 func TestSyncGroup_Mixed(t *testing.T) {
 	// Covers the case of mixed function types, some that sync and some that don't
-	iters := 2000000
+	iters := iterCount(2000000)
 	decrements := int32(iters)
 	increments := int32(0)
 
@@ -91,8 +100,8 @@ func TestSyncGroup_Mixed(t *testing.T) {
 
 func TestSyncGroup_MultiAdd(t *testing.T) {
 	// Add many batches
-	iters := 1000000
-	batches := 100
+	iters := iterCount(1000000)
+	batches := iters / 10
 	decrements := int32(iters)
 	increments := int32(0)
 


### PR DESCRIPTION
Hey,

As discussed your code was racy. This fixes some of that. I don't know how sure I feel about this approach, but I figured I'd give it a go. Salient changes:

 - removed use of sync.WaitGroup
 - made use of sync.Cond
 - added SyncGroup.Add

As described below I'm not confident this is good code; I'm mostly submitting it as it's an improvement to the original and my brain is fried trying to think of the various races that could happen.

Thanks for inspiring me to hack on something :)

Below are notes:

## sync.WaitGroup

Unfortunately you cannot inspect a waitgroup to see how many jobs are left in it. As such it doesn't lend well to this role, especially since the book keeping to know how many are in "waiting for sync" state and in running state is essentially the same with or without the waitgroup; it didn't seem to offer much so I removed it reluctantly. WaitGroup makes use of runtime constructs we cannot easily access at our level of go (notably semaphores from the runtime [[link](https://github.com/golang/go/blob/master/src/sync/waitgroup.go#L131)]). As a result I'm pretty confident there are all sorts of nasties in this code.

## sync.Cond

There was a fun interplay between `Wait()` and `Sync()`; since `Sync()` get's called in the go routine you want `Wait()` to finish after the functions have all finished; thus `WaitGroup` does not work. Additionally since different routines will call `Sync()` and `Wait()` you want `Wait()` to block in a manner that allows execution to restart at the appropriate time; enter `sync.Cond`. Its `Wait()` and `Broadcast()` functions permit you to block and notify.

## SyncGroup.Add

It wasn't really possible to tackle a key race without changing the SyncGroup API; and surfacing Add(). I liked your plan to hide it in implementation details however there was just no way to ensure the state transition into `Sync()`/`Wait()` happened at the right time without explicitly asking the user to make a decision. WaitGroup actually handle this better than SyncGroup because the code spinning up go routines and calling `wg.Add(1)` is usually linear; `Sync()`, especially, changes this dramatically. As such, there is still a race here where one go routine can hit sync before another one is enqueued and as such execute the sync state incorrectly. As such it's important that users are aware of this. 

### Other concerns

 * I made minimal changes to your example (`sg.Add(10)`) - so I'm confident that your use cases will continue to work if you add that call.
 * I added additional tests. The initial ones (`TestSyncGroup_Wait` and `TestSyncGroup_Sync`) prior to goofing around in the internals, these were able to demonstrate the races in your initial code
 * I lock a heck of a lot - perhaps with fresh eyes the locking could be reduced. It's particularly painful with a large number of goroutines calling `Sync()`.

Test run:

```
$ go test -v ./...
=== RUN   TestSyncGroup_Wait
--- PASS: TestSyncGroup_Wait (0.78s)
=== RUN   TestSyncGroup_Sync
--- PASS: TestSyncGroup_Sync (10.39s)
=== RUN   TestSyncGroup_Mixed
--- PASS: TestSyncGroup_Mixed (21.47s)
=== RUN   TestSyncGroup_MultiAdd
--- PASS: TestSyncGroup_MultiAdd (8.72s)
=== RUN   ExampleSyncGroup
--- PASS: ExampleSyncGroup (0.00s)
PASS
ok  	github.com/ossareh/syncgroup	41.451s
```

... with race detector:

```
$ RACE_TEST=1 go test -v -race ./...
=== RUN   TestSyncGroup_Wait
--- PASS: TestSyncGroup_Wait (0.00s)
=== RUN   TestSyncGroup_Sync
--- PASS: TestSyncGroup_Sync (0.00s)
=== RUN   TestSyncGroup_Mixed
--- PASS: TestSyncGroup_Mixed (0.00s)
=== RUN   TestSyncGroup_MultiAdd
--- PASS: TestSyncGroup_MultiAdd (0.00s)
=== RUN   ExampleSyncGroup
--- PASS: ExampleSyncGroup (0.00s)
PASS
ok  	github.com/ossareh/syncgroup	1.041s
```